### PR TITLE
Fix roadmap heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We welcome your contributions and PRs.
 - [ ] Enhanced Link Management (with Cloudflare D1)
 - [ ] Analytics Enhancements (Support for merging filter conditions)
 - [ ] Dashboard Performance Optimization (Infinite loading)
-- [ ] Units Test
+ - [ ] Unit Tests
 - [ ] Support for Other Deployment Platforms
 
 ## 🏗️ Deployment


### PR DESCRIPTION
## Summary
- fix typo in README roadmap section

## Testing
- `npm run lint` *(fails: Cannot find package '@antfu/eslint-config')*