### PR TITLE
Add Vitest setup and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ We welcome your contributions and PRs.
 - [ ] Units Test
 - [ ] Support for Other Deployment Platforms
 
+## 🧪 Testing
+
+Run unit tests with [Vitest](https://vitest.dev):
+
+```bash
+pnpm vitest
+```
+
 ## 🏗️ Deployment
 
 > Video tutorial: [Watch here](https://www.youtube.com/watch?v=MkU23U2VE9E)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "nuxt typecheck",
     "wrangler": "wrangler",
-    "lint-staged": "lint-staged"
+    "lint-staged": "lint-staged",
+    "vitest": "vitest"
   },
   "dependencies": {
     "@number-flow/vue": "^0.3.3",
@@ -60,7 +61,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "vue-tsc": "^2.2.0",
-    "wrangler": "^3.99.0"
+    "wrangler": "^3.99.0",
+    "vitest": "^1.5.0"
   },
   "simple-git-hooks": {
     "pre-commit": "npm run lint-staged"

--- a/tests/utils/flag.test.ts
+++ b/tests/utils/flag.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { getFlag } from '../../utils/flag'
+
+describe('getFlag', () => {
+  it('returns emoji for valid country codes', () => {
+    expect(getFlag('US')).toBe('🇺🇸')
+    expect(getFlag('DE')).toBe('🇩🇪')
+    expect(getFlag('CN')).toBe('🇨🇳')
+  })
+
+  it('returns undefined for invalid input', () => {
+    // empty string and lower case
+    expect(getFlag('')).toBeUndefined()
+    expect(getFlag('us')).toBeUndefined()
+    // too many letters
+    expect(getFlag('USA')).toBeUndefined()
+    // contains numbers
+    expect(getFlag('1A')).toBeUndefined()
+  })
+})

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest"]
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- add Vitest dev dependency and script
- configure Vitest
- add `tests/utils/flag.test.ts`
- document running tests in README

## Testing
- `npm run vitest` *(fails: vitest not found)*